### PR TITLE
Generate the bootstrap indexes in a generator function.

### DIFF
--- a/scikits/bootstrap/bootstrap.py
+++ b/scikits/bootstrap/bootstrap.py
@@ -275,7 +275,8 @@ Given data points data, where axis 0 is considered to delineate points, return
 an array where each row is a set of bootstrap indexes. This can be used as a list
 of bootstrap indexes as well.
     """
-    return randint(data.shape[0],size=(n_samples,data.shape[0]) )
+    for _ in xrange(n_samples):
+        yield randint(data.shape[0], size=(data.shape[0],))
 
 def jackknife_indexes(data):
     """


### PR DESCRIPTION
This means that we don't need to pull all of the indexes for each
sample into memory at the same time.

Prior to this change, bootstrapping 30000 samples for 10k iterations
used 2GB of memory. After the change, it uses 60M.