### PR TITLE
Added functionality for moving-block bootstrap

### DIFF
--- a/scikits/bootstrap/bootstrap.py
+++ b/scikits/bootstrap/bootstrap.py
@@ -319,7 +319,7 @@ samples)
 
 
 def it_moving_blocks(n_obs, block_length, truncate=True):
-    '''Generator for moving block boottrap
+    '''Generator for moving-block boottrap.
 
     Notes
     -----
@@ -354,6 +354,13 @@ def it_moving_blocks(n_obs, block_length, truncate=True):
 
 
 def bootstrap_indexes_mblocks(data, n_samples=10000, block_lenght=3, truncate=True):
+    """Generate moving-block bootstrap samples.
+
+    Given data points data, where axis 0 is considered to delineate points,
+    return an generator for sets of bootstrap indexes. This can be used as a
+    list of bootstrap indexes (with list(bootstrap_indexes_mblocks(data))) as
+    well.
+    """
     n_obs = data.shape[0]
     idx = np.arange(n_obs)
     iter_obj = it_moving_blocks(n_obs, block_lenght, truncate)

--- a/scikits/bootstrap/bootstrap.py
+++ b/scikits/bootstrap/bootstrap.py
@@ -356,10 +356,9 @@ def it_moving_blocks(n_obs, block_length, truncate=True):
 def bootstrap_indexes_mblocks(data, n_samples=10000, block_lenght=3, truncate=True):
     """Generate moving-block bootstrap samples.
 
-    Given data points data, where axis 0 is considered to delineate points,
-    return an generator for sets of bootstrap indexes. This can be used as a
-    list of bootstrap indexes (with list(bootstrap_indexes_mblocks(data))) as
-    well.
+    Given data points `data`, where axis 0 is considered to delineate points,
+    return a generator for sets of bootstrap indexes. This can be used as a
+    list of bootstrap indexes (with list(bootstrap_indexes_mblocks(data))) as well.
     """
     n_obs = data.shape[0]
     idx = np.arange(n_obs)

--- a/scikits/bootstrap/bootstrap.py
+++ b/scikits/bootstrap/bootstrap.py
@@ -317,3 +317,44 @@ samples)
     for sample in base: np.random.shuffle(sample)
     return base[:,0:size]
 
+
+def it_moving_blocks(n_obs, block_length, truncate=True):
+    '''Generator for moving block boottrap
+
+    Notes
+    -----
+    This uses wrapping from the end to the beginning of the data series.
+
+    If truncate is True, then the returned index is valid for the original
+    data series.
+
+    If truncate is False, then the returned index array has a largest possible
+    index equal to ``n_obs + block_length - 2``. It needs to index into an
+    array that has the first ``block_length - 1`` observations concatenated
+    to the end.
+
+    #TODO: reverse indexing so we have negative indices for automatic wrapping
+
+    '''
+    n_blocks = int(np.ceil(n_obs * 1. / block_length))
+    idx0 = np.cumsum(np.ones((n_blocks, block_length), int), 1) - 1
+
+    while True:
+        # wrap with negative
+        #start = np.random.randint(0, n_obs, size=n_blocks)
+        start = np.random.randint(0, n_obs, size=n_blocks) - block_length + 1
+
+        # moving blocks, with overlap
+        idx = (idx0 + start[:,None]).ravel()
+        if truncate:
+            # reindex wrapped observations
+            mask = idx >= n_obs
+            idx[mask] -= n_obs
+        yield idx[:n_obs]
+
+
+def bootstrap_indexes_mblocks(data, n_samples=10000, block_lenght=3, truncate=True):
+    n_obs = data.shape[0]
+    idx = np.arange(n_obs)
+    iter_obj = it_moving_blocks(n_obs, block_lenght, truncate)
+    return np.array([idx[iter_obj.next()] for _ in range(n_samples)])

--- a/scikits/bootstrap/test_bootstrap.py
+++ b/scikits/bootstrap/test_bootstrap.py
@@ -26,6 +26,11 @@ class test_ci():
         indexes = np.array([x for x in boot.bootstrap_indexes(np.array([1,2,3,4,5]), n_samples=3)])
         np.testing.assert_array_equal(indexes, np.array([[2, 4, 3, 1, 3],[1, 4, 1, 4, 4],[0, 2, 1, 4, 4]]))
 
+    def test_bootstrap_indexes_mblocks(self):
+        np.random.seed(1234567890)
+        indexes = np.array([x for x in boot.bootstrap_indexes_mblocks(np.array([1,2,3,4,5]), n_samples=3)])
+        np.testing.assert_array_equal(indexes, np.array([[0, 1, 2, 2, 3],[1, 2, 3, 4, 0],[1, 2, 3, 4, 0]]))
+
     def test_jackknife_indexes(self):
         np.random.seed(1234567890)
         indexes = np.array([x for x in boot.jackknife_indexes(np.array([1,2,3]))])


### PR DESCRIPTION
Hi Evans,

In case you're interested, I've added a couple of (simple) functions to perform the moving-block bootstrap. I modified these functions from a forum (I can't remember which one now) while searching for bootstrap methods applied to time-dependent data (i.e., time series). I've used this technique, along with the scikits-bootstrap package, to derive uncertainties for trend-fit on several time series. In this case, since the time series have a temporal structure both in the long-term (the trend) and in the short-term (coherent fluctuations), one must (i) apply bootstrapping to the residuals of the fit and (ii) use blocks of predefined length to preserve the structure of local auto-correlation.

I can also contribute with some doc/examples if you think adding this functionality/code is worthy.
