### PR TITLE
Fix ValueError in _avals_bca for NumPy 2.x by using np.atleast_1d.

### DIFF
--- a/src/scikits/bootstrap/bootstrap.py
+++ b/src/scikits/bootstrap/bootstrap.py
@@ -606,6 +606,7 @@ def _avals_bca(
         6.0 * np.sum((jmean - jstat) ** 2, axis=0) ** 1.5
     )
     if np.any(np.isnan(a)):
+        a = np.atleast_1d(a)
         nanind = np.nonzero(np.isnan(a))
         warnings.warn(
             "BCa acceleration values for indices {} were undefined. \


### PR DESCRIPTION
Fixes `ValueError` in `test_allequal_warn` with NumPy 2.x, where `np.nonzero(np.isnan(a))` fails on scalar `NaN`. Added `a = np.atleast_1d(a)` in `_avals_bca` to ensure compatibility. Tested with NumPy 2.x and 1.26.5.

Closes #37